### PR TITLE
NA detection of signed fields corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.0.2
+
+- Bug fix: detection of NA values in signed fields (temperate and acceleration) has been corrected.
+
 ### v1.0.1
 
  - Added release/distribution management to the project. No functional changes in code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### v1.0.1
 
- - Added release/distribution management to the project. No functional changes in code.
+- Added release/distribution management to the project. No functional changes in code.
 
 ## v1.0.0
 
- - First release
+- First release

--- a/src/main/java/fi/tkgwf/ruuvi/common/parser/impl/DataFormat5Parser.java
+++ b/src/main/java/fi/tkgwf/ruuvi/common/parser/impl/DataFormat5Parser.java
@@ -7,11 +7,12 @@ import fi.tkgwf.ruuvi.common.parser.DataFormatParser;
 
 public class DataFormat5Parser implements DataFormatParser {
 
-    private final int[] RUUVI_COMPANY_IDENTIFIER = {0x99, 0x04}; // 0x0499
+    private final int[] RUUVI_COMPANY_IDENTIFIER = { 0x99, 0x04 }; // 0x0499
 
     @Override
     public RuuviMeasurement parse(byte[] data) {
-        if (data.length < 2 || (data[0] & 0xFF) != RUUVI_COMPANY_IDENTIFIER[0] || (data[1] & 0xFF) != RUUVI_COMPANY_IDENTIFIER[1]) {
+        if (data.length < 2 || (data[0] & 0xFF) != RUUVI_COMPANY_IDENTIFIER[0]
+                || (data[1] & 0xFF) != RUUVI_COMPANY_IDENTIFIER[1]) {
             return null;
         }
         data = Arrays.copyOfRange(data, 2, data.length); // discard the first 2 bytes, the company identifier
@@ -21,7 +22,7 @@ public class DataFormat5Parser implements DataFormatParser {
         RuuviMeasurement m = new RuuviMeasurement();
         m.setDataFormat(data[0] & 0xFF);
 
-        if (!ByteUtils.isMaxSignedShort(data[1], data[2])) {
+        if (!ByteUtils.isMinSignedShort(data[1], data[2])) {
             m.setTemperature((data[1] << 8 | data[2] & 0xFF) / 200d);
         }
 
@@ -33,13 +34,13 @@ public class DataFormat5Parser implements DataFormatParser {
             m.setPressure((double) ((data[5] & 0xFF) << 8 | data[6] & 0xFF) + 50000);
         }
 
-        if (!ByteUtils.isMaxSignedShort(data[7], data[8])) {
+        if (!ByteUtils.isMinSignedShort(data[7], data[8])) {
             m.setAccelerationX((data[7] << 8 | data[8] & 0xFF) / 1000d);
         }
-        if (!ByteUtils.isMaxSignedShort(data[9], data[10])) {
+        if (!ByteUtils.isMinSignedShort(data[9], data[10])) {
             m.setAccelerationY((data[9] << 8 | data[10] & 0xFF) / 1000d);
         }
-        if (!ByteUtils.isMaxSignedShort(data[11], data[12])) {
+        if (!ByteUtils.isMinSignedShort(data[11], data[12])) {
             m.setAccelerationZ((data[11] << 8 | data[12] & 0xFF) / 1000d);
         }
 

--- a/src/main/java/fi/tkgwf/ruuvi/common/utils/ByteUtils.java
+++ b/src/main/java/fi/tkgwf/ruuvi/common/utils/ByteUtils.java
@@ -31,10 +31,23 @@ public abstract class ByteUtils {
      * @param b1 1st byte to check
      * @param b2 2nd byte to check
      * @return true if the pair of bytes represent the max value a signed short
-     * can be
+     *         can be
      */
     public static boolean isMaxSignedShort(byte b1, byte b2) {
         return isMaxSignedByte(b1) && isMaxUnsignedByte(b2);
+    }
+
+    /**
+     * Convenience method for checking whether the supplied bytes forming a
+     * 16bit short is the min signed short.
+     *
+     * @param b1 1st byte to check
+     * @param b2 2nd byte to check
+     * @return true if the pair of bytes represent the min value a signed short
+     *         can be
+     */
+    public static boolean isMinSignedShort(byte b1, byte b2) {
+        return (b1 & 0xff) == 0x80 && (b2 & 0xff) == 0x00;
     }
 
     /**
@@ -44,7 +57,7 @@ public abstract class ByteUtils {
      * @param b1 1st byte to check
      * @param b2 2nd byte to check
      * @return true if the pair of bytes represent the max value an unsigned
-     * short can be
+     *         short can be
      */
     public static boolean isMaxUnsignedShort(byte b1, byte b2) {
         return isMaxUnsignedByte(b1) && isMaxUnsignedByte(b2);

--- a/src/test/java/fi/tkgwf/ruuvi/common/ParserTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/common/ParserTest.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 
 import org.apache.commons.codec.binary.Hex;
 
-
 public class ParserTest extends TestCase {
     private AnyDataFormatParser parser;
 
@@ -56,9 +55,9 @@ public class ParserTest extends TestCase {
         this.parser = new AnyDataFormatParser();
     }
 
-
     /**
-     * test_decode_is_valid in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_decode_is_valid in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDecodeEddystone() {
@@ -76,9 +75,9 @@ public class ParserTest extends TestCase {
         assertNull(m.getTxPower());
     }
 
-
     /**
-     * test_decode_is_valid_case in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_decode_is_valid_case in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDecodeEddystone2() {
@@ -97,13 +96,14 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * test_decode_is_valid_weatherstation_2017_04_12 in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_decode_is_valid_weatherstation_2017_04_12 in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDecodeEddystone3() {
         // https://ruu.vi/#AjUX1MAw0
         RuuviMeasurement m = parser.parse(eddystoneData("AjUX1MAw0"));
-//        assertEquals(23.828125, m.getTemperature());
+        // assertEquals(23.828125, m.getTemperature());
         assertEquals(99200.0, m.getPressure());
         assertEquals(26.5, m.getHumidity());
         assertEquals((Integer) 2, m.getDataFormat());
@@ -115,14 +115,15 @@ public class ParserTest extends TestCase {
         assertNull(m.getTxPower());
     }
 
-
     /**
-     * test_df3decode_is_valid in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_df3decode_is_valid in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDataFormat3() {
         // {format}{humidity}{temp}{pressure}{accX}{accY}{accZ}{batt}
-        RuuviMeasurement m = parser.parse(dataWithCompany("03-29-1A1E-CE1E-FC18-F942-02CA-0B5300000000BB".replace("-", "")));
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("03-29-1A1E-CE1E-FC18-F942-02CA-0B5300000000BB".replace("-", "")));
         assertEquals(26.3, m.getTemperature());
         assertEquals(102766.0, m.getPressure());
         assertEquals(20.5, m.getHumidity());
@@ -135,7 +136,8 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * test_df3decode_is_valid in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_df3decode_is_valid in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDataFormat3Alt() {
@@ -153,12 +155,14 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * test_df3decode_is_valid_max_values in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_df3decode_is_valid_max_values in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDataFormat3MaxValues() {
         // {format}{humidity}{temp}{pressure}{accX}{accY}{accZ}{batt}
-        RuuviMeasurement m = parser.parse(dataWithCompany("03-C8-7F63-FFFF-03E8-03E8-03E8-FFFF-00000000BB".replace("-", "")));
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("03-C8-7F63-FFFF-03E8-03E8-03E8-FFFF-00000000BB".replace("-", "")));
         assertEquals(127.99, m.getTemperature());
         assertEquals(115535.0, m.getPressure());
         assertEquals(100.0, m.getHumidity());
@@ -173,12 +177,14 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * test_df3decode_is_valid_min_values in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_df3decode_is_valid_min_values in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDataFormat3MinValues() {
         // {format}{humidity}{temp}{pressure}{accX}{accY}{accZ}{batt}
-        RuuviMeasurement m = parser.parse(dataWithCompany("03-00-FF63-0000-FC18-FC18-FC18-0000-00000000BB".replace("-", "")));
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("03-00-FF63-0000-FC18-FC18-FC18-0000-00000000BB".replace("-", "")));
         assertEquals(-127.99, m.getTemperature());
         assertEquals(50000.0, m.getPressure());
         assertEquals(0.0, m.getHumidity());
@@ -193,12 +199,14 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * test_df5decode_is_valid in https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
+     * test_df5decode_is_valid in
+     * https://github.com/ttu/ruuvitag-sensor/blob/master/tests/test_decoder.py
      */
     @Test
     public void testDataFormat5() {
         // {format}{temp}{humidity}{pressure}{accX}{accY}{accZ}{power_info}{movement_counter}{measurement_sequence}{mac}
-        RuuviMeasurement m = parser.parse(dataWithCompany("05-12FC-5394-C37C-0004-FFFC-040C-AC36-42-00CD-CBB8334C884F".replace("-", "")));
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("05-12FC-5394-C37C-0004-FFFC-040C-AC36-42-00CD-CBB8334C884F".replace("-", "")));
         assertEquals(24.3, m.getTemperature());
         assertEquals(100044.0, m.getPressure());
         assertEquals(53.49, m.getHumidity());
@@ -213,44 +221,109 @@ public class ParserTest extends TestCase {
     }
 
     /**
-     * See https://github.com/ruuvi/ruuvi-sensor-protocols and "reference" python implementation
-     */
-    @Test
-    public void testDataFormat5AllUnavailable() {
-        // {format}{temp}{humidity}{pressure}{accX}{accY}{accZ}{power_info}{movement_counter}{measurement_sequence}{mac}
-        RuuviMeasurement m = parser.parse(dataWithCompany("05-7FFF-FFFF-FFFF-7FFF-7FFF-7FFF-FFFF-FF-FFFF-CBB8334C884F".replace("-", "")));
-        assertNull( m.getTemperature());
-        assertNull( m.getPressure());
-        assertNull( m.getHumidity());
-        assertNull( m.getBatteryVoltage());
-        assertNull( m.getAccelerationX());
-        assertNull( m.getAccelerationY());
-        assertNull( m.getAccelerationZ());
-        assertEquals((Integer) 5, m.getDataFormat());
-        assertNull( m.getMeasurementSequenceNumber());
-        assertNull( m.getMovementCounter());
-        assertNull( m.getTxPower());
-    }
-
-
-    /**
-     * See https://github.com/ruuvi/ruuvi-sensor-protocols and "reference" python implementation
+     * See https://github.com/ruuvi/ruuvi-sensor-protocols and "reference" python
+     * implementation
      */
     @Test
     public void testDataFormat5SomeUnavailable() {
         // {format}{temp}{humidity}{pressure}{accX}{accY}{accZ}{power_info}{movement_counter}{measurement_sequence}{mac}
-        RuuviMeasurement m = parser.parse(dataWithCompany("05-12FC-FFFF-C37C-7FFF-7FFF-7FFF-FFFF-FF-FFFF-CBB8334C884F".replace("-", "")));
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("05-12FC-FFFF-C37C-8000-8000-8000-FFFF-FF-FFFF-CBB8334C884F".replace("-", "")));
         assertEquals(24.3, m.getTemperature());
         assertEquals(100044.0, m.getPressure());
-        assertNull( m.getHumidity());
-        assertNull( m.getBatteryVoltage());
-        assertNull( m.getAccelerationX());
-        assertNull( m.getAccelerationY());
-        assertNull( m.getAccelerationZ());
+        assertNull(m.getHumidity());
+        assertNull(m.getBatteryVoltage());
+        assertNull(m.getAccelerationX());
+        assertNull(m.getAccelerationY());
+        assertNull(m.getAccelerationZ());
         assertEquals((Integer) 5, m.getDataFormat());
-        assertNull( m.getMeasurementSequenceNumber());
-        assertNull( m.getMovementCounter());
-        assertNull( m.getTxPower());
+        assertNull(m.getMeasurementSequenceNumber());
+        assertNull(m.getMovementCounter());
+        assertNull(m.getTxPower());
+    }
+
+    /**
+     * "Valid data" official test vector
+     * hhttps://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2
+     */
+    @Test
+    public void testDataFormat5TestVectorValid() {
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("0512FC5394C37C0004FFFC040CAC364200CDCBB8334C884F"));
+        assertEquals(24.3, m.getTemperature());
+        assertEquals(100044.0, m.getPressure());
+        assertEquals(53.49, m.getHumidity());
+        assertEquals(2.9770000000000003, m.getBatteryVoltage());
+        assertEquals(0.004, m.getAccelerationX());
+        assertEquals(-0.004, m.getAccelerationY());
+        assertEquals(1.036, m.getAccelerationZ());
+        assertEquals((Integer) 5, m.getDataFormat());
+        assertEquals((Integer) 205, m.getMeasurementSequenceNumber());
+        assertEquals((Integer) 66, m.getMovementCounter());
+        assertEquals((Integer) 4, m.getTxPower());
+    }
+
+    /**
+     * "Maximum values" official test vector
+     * https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2
+     */
+    @Test
+    public void testDataFormat5TestVectorMaxValues() {
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("057FFFFFFEFFFE7FFF7FFF7FFFFFDEFEFFFECBB8334C884F"));
+        assertEquals(163.835, m.getTemperature());
+        assertEquals(115534.0, m.getPressure());
+        assertEquals(163.8350, m.getHumidity());
+        assertEquals(3.646, m.getBatteryVoltage());
+        assertEquals(32.767, m.getAccelerationX());
+        assertEquals(32.767, m.getAccelerationY());
+        assertEquals(32.767, m.getAccelerationZ());
+        assertEquals((Integer) 5, m.getDataFormat());
+        assertEquals((Integer) 65534, m.getMeasurementSequenceNumber());
+        assertEquals((Integer) 254, m.getMovementCounter());
+        assertEquals((Integer) 20, m.getTxPower());
+    }
+
+    /**
+     * "Minimum values" official test vector
+     * https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2
+     */
+    @Test
+    public void testDataFormat5TestVectorMinValues() {
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("058001000000008001800180010000000000CBB8334C884F"));
+        assertEquals(-163.835, m.getTemperature());
+        assertEquals(50000.0, m.getPressure());
+        assertEquals(0.0, m.getHumidity());
+        assertEquals(1.6, m.getBatteryVoltage());
+        assertEquals(-32.767, m.getAccelerationX());
+        assertEquals(-32.767, m.getAccelerationY());
+        assertEquals(-32.767, m.getAccelerationZ());
+        assertEquals((Integer) 5, m.getDataFormat());
+        assertEquals((Integer) 0, m.getMeasurementSequenceNumber());
+        assertEquals((Integer) 0, m.getMovementCounter());
+        assertEquals((Integer) (-40), m.getTxPower());
+    }
+
+    /**
+     * "Invalid values" official test vector
+     * https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_05.md
+     */
+    @Test
+    public void testDataFormat5TestVectorInvalidValues() {
+        RuuviMeasurement m = parser
+                .parse(dataWithCompany("058000FFFFFFFF800080008000FFFFFFFFFFFFFFFFFFFFFF"));
+        assertNull(m.getTemperature());
+        assertNull(m.getPressure());
+        assertNull(m.getHumidity());
+        assertNull(m.getBatteryVoltage());
+        assertNull(m.getAccelerationX());
+        assertNull(m.getAccelerationY());
+        assertNull(m.getAccelerationZ());
+        assertEquals((Integer) 5, m.getDataFormat());
+        assertNull(m.getMeasurementSequenceNumber());
+        assertNull(m.getMovementCounter());
+        assertNull(m.getTxPower());
     }
 
     @Test

--- a/src/test/java/fi/tkgwf/ruuvi/common/ParserTest.java
+++ b/src/test/java/fi/tkgwf/ruuvi/common/ParserTest.java
@@ -8,8 +8,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.Before;
 
-import java.util.Arrays;
-
 import org.apache.commons.codec.binary.Hex;
 
 public class ParserTest extends TestCase {


### PR DESCRIPTION
As stated in docs and re-iterated with the official test vectors,
NA values with signed fields are denoted by "smallest presentable
number for signed values", i.e. 0x8000 (or -32768).

Turned out that some of the tests were incorrect, now corrected here.

Note: `ByteUtils::isMaxSignedShort` is now unused by the library itself but was
preserved -- one could consider it part of public API. In case this is removed, it might be consider semver-wise backwards incompatible API change, and would possibly warrant major version bump. That is, if this project follows semver.

[1] https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2

Fixes #4